### PR TITLE
Still render if DOM content is somehow loaded

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,11 @@ export const config = {
 };
 
 export function render({ delay = 0 }: EzTipOptions = {}) {
-    window.addEventListener('DOMContentLoaded', () => onRender({ delay }))
+  if (document.readyState !== "loading") {
+    onRender({ delay });
+  } else {
+    window.addEventListener("DOMContentLoaded", () => onRender({ delay }));
+  }
 }
 
 function onRender({


### PR DESCRIPTION
Still allow `onRender` if `document.readyState` is `complete` or `interactive`. If it's still `loading`, fall back to waiting on `DOMContentLoaded`.

Fixes #2.